### PR TITLE
Version 1.0.1

### DIFF
--- a/IndividualSteps/configure_tcpip.sh
+++ b/IndividualSteps/configure_tcpip.sh
@@ -31,7 +31,9 @@ echo -e "\033[32mConfiguring Network Settings\033[0m"
 IFS=. read -r i1 i2 i3 i4 <<< "$ipAddress"
 IFS=. read -r m1 m2 m3 m4 <<< "$netmask"
 
-cidr=$(echo "obase=2; $(( (m1 << 24) + (m2 << 16) + (m3 << 8) + m4 ))" | bc | tr -d '\n' | sed 's/0*$//' | wc -c)
+maskDec=$(( (m1 * 16777216) + (m2 * 65536) + (m3 * 256) + m4 ))
+maskBin=$(echo "obase=2; $maskDec" | bc)
+cidr=$(echo "$maskBin" | tr -d '\n' | sed 's/0*$//' | wc -c)
 
 cat <<EOF | sudo tee /etc/netplan/01-netcfg.yaml > /dev/null
 network:

--- a/NodeParameters_Master.md
+++ b/NodeParameters_Master.md
@@ -17,6 +17,7 @@ Parameter values which are wraped in quotes must include the quotes when applied
 |`--k8s-version`|The version of Kubernetes to install.|`latest`|`1.25.0-00`|No|
 |`--k8s-load-balancer-ip-range`|The IP range or CIDR for Kubernetes load balancer.|-|`192.168.0.10-192.168.0.15`<br>or<br>`192.168.0.1/24`|No|
 |`--k8s-allow-master-node-schedule`|Set to `true` to allow master node to schedule pods.|`true`|`false`|No|
+|`--k8s-kubeadm-options`|Additional options to pass into the `kubeadm init` command.|-|`"--ignore-preflight-errors=all"`|No|
 |`--nfs-install-server`|Set to `true` to install NFS server.|`true`|`false`|No|
 |`--nfs-server`|The NFS server to use.|`$HOSTNAME`|`192.168.0.100`|When `--nfs-install-server` is `true`|
 |`--nfs-share-path`|The NFS share path to use.|`/shares/nfs`|`/mnt/nfs`|When `--nfs-install-server` is `true`|
@@ -60,14 +61,14 @@ Example Usage - Minimum Required:
 
 ```
 ./setup_master_node.sh \
-    --dns-servers "192.168.0.30 192.168.0.31 8.8.8.8"
+    --k8s-load-balancer-ip-range 192.168.0.20-192.168.0.29
 ```
 <p style="width=100%; text-align: center; font-style: italic">Or if your server has more than one IP address</p>
 
 ```
 ./setup_master_node.sh \
     --ip-address 192.168.0.230 \
-    --dns-servers "192.168.0.30 192.168.0.31 8.8.8.8"
+    --k8s-load-balancer-ip-range 192.168.0.20-192.168.0.29
 ```
 
 <br>
@@ -118,6 +119,15 @@ Example Usage - No Storage (No CSI drivers or Storage Classes will be installed)
 ```
 
 <br>
+Example Usage - Additional kubeadm init options
+
+```
+./setup_master_node.sh \  
+    --k8s-kubeadm-options "--ignore-preflight-errors=all" 
+```
+> Available options for `kubeadm init` [here](https://kubernetes.io/docs/reference/setup-tools/kubeadm/kubeadm-init/). <br> **Do not** include `--apiserver-advertise-address` or `--pod-network-cidr` as these are already set in the script.
+
+<br>
 Example Usage - All:
 
 ```
@@ -132,6 +142,7 @@ Example Usage - All:
     --k8s-version 1.26.0-00 \
     --k8s-load-balancer-ip-range 192.168.0.20-192.168.0.29 \
     --k8s-allow-master-node-schedule true \
+    --k8s-kubeadm-options "--ignore-preflight-errors=all" \
     --nfs-install-server true \
     --nfs-server srv-k8s-master.domain1.local \
     --nfs-share-path /some/path/nfs \

--- a/NodeParameters_Worker.md
+++ b/NodeParameters_Worker.md
@@ -20,6 +20,7 @@ Parameters that have default values but are marked as required can still be ommi
 |`--k8s-version`|The version of Kubernetes to install.|`latest`|`1.25.0-00`|No|
 |`--k8s-master-ip`|The IP address of the control-plane node.|-|`192.168.0.10`|Yes|
 |`--k8s-master-port`|The Kubernetes API server port on the control-plane node.|`6443`|`6443`|Yes|
+|`--k8s-kubeadm-options`|Additional options to pass into the `kubeadm join` command.|-|`"--ignore-preflight-errors=all"`|No|
 |`--token`|The `token` portion of the `kubeadm join` command.|-|`kspnlk.7h[..]3f`|Yes|
 |`--discovery-token-ca-cert-hash`|The `discovery-token-ca-cert-hash` portion of the `kubeadm join` command.|-|`sha256:68d[..]bb2`|Yes|
 
@@ -42,6 +43,15 @@ Example Usage - Minimum Required:
 ```
 
 <br>
+Example Usage - Additional kubeadm join options
+
+```
+./setup_master_node.sh \  
+    --k8s-kubeadm-options "--ignore-preflight-errors=all" 
+```
+> Available options for `kubeadm join` [here](https://kubernetes.io/docs/reference/setup-tools/kubeadm/kubeadm-join/). <br> **Do not** include `--token` or `--discovery-token-ca-cert-hash` as these are already set in the script.
+
+<br>
 Example Usage - All:
 
 ```
@@ -55,6 +65,7 @@ Example Usage - All:
     --dns-search "domain1.local domain2.local" \
     --k8s-master-ip 192.168.0.230 \
     --k8s-master-port 6443 \
+    --k8s-kubeadm-options "--ignore-preflight-errors=all" \
     --token fbdzi9.5yedbdve20r \
     --discovery-token-ca-cert-hash sha256:68d0860434a20c9eb533b640f23134c0fdacc4b929e97c8f8e537f9b4befabb2 
 ```

--- a/README.md
+++ b/README.md
@@ -14,12 +14,6 @@ Here's a video that demonstrates a brand-new 2 node cluster being created in jus
 
 [![Self-Hosted Kubernetes Cluster in 5 Minutes](https://user-images.githubusercontent.com/13077550/223282256-3fd23787-94a8-4789-bbeb-8e47c8963a7e.png)](https://www.youtube.com/watch?v=KK3W76xrN9E "Self-Hosted Kubernetes Cluster in 5 Minutes")
 
-## Future Plans
-
-There will be a separate set of scripts for those wanting to make use of the vSphere CPI and CSI drivers, and possibly in the future other drivers or hardware/environments as well. 
-
-This project is very early days and has only been tested on Ubuntu 20.04 running on VMware ESXi (without the CPI and CSI drivers) and Hyper-V. In future more testing will be performed to ensure it works as expected in other environment. If you do use this in a different environment, please let me know your findings and feel free to create pull requests if you discover any issues and find fixes for them.
-
 ## What Does This Do?
 
 ### Master (Control-Plane) Node Script:
@@ -37,6 +31,8 @@ Here's a high-level overview of the steps `setup_master_node.sh` will perform:
 - Installs Docker CE and containerd, then applies required configuration for Kubernetes.
 
 - Installs Kubernetes packages.
+
+- Configures prerequisites such as disabling swap and enabling IPv4 packet forwarding
 
 - Initializes Kubernetes with the `kubeadm init` command.
 
@@ -75,6 +71,8 @@ Here's a high-level overview of the steps `setup_worker_node.sh` will perform:
 - Installs Docker CE and containerd, then applies required configuration for Kubernetes.
 
 - Installs Kubernetes packages.
+
+- Configures prerequisites such as disabling swap and enabling IPv4 packet forwarding
 
 - Joins the Kubernetes cluster using the `kubeadm join` command.
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,21 @@
+
+---
+### 1.0.1
+*March 23th 2025*
+
+- Use community package repository (pkgs.k8s.io). (Google ones are dead)
+- Use GitHub to determine latest version (required due to the above).
+- Add validation for `--k8s-version` parameter.
+- Reorder steps, placing prerequisite config between package install and `kubeadm [init|join]`. Also place splash and sudo checks at top of script.
+- Add script version to banner.
+- Change CIDR generator code so it doesn't break syntax highlighting.
+- Added `--k8s-kubeadm-options` parameter.
+- Added `set -euo pipefail` to terminate script on failure.
+- Update documentation.
+- Added 1 second sleep before `apt-get update` due to observed file locks / race conditions.
+- Added changelog.md.
+
+Tested with:
+
+- Ubuntu Server 24.04
+- Kubernetes Version 1.32.3

--- a/setup_master_node.sh
+++ b/setup_master_node.sh
@@ -352,9 +352,9 @@ fi
 # Add Kubernetes Respository
 
 if [ ! -f /etc/apt/sources.list.d/kubernetes.list ]; then
-  echo -e "\033[32mAdding Google Kubernetes repository\033[0m"
-  curl -fsSLo $KEYRINGS_DIR/kubernetes-archive-keyring.gpg https://dl.k8s.io/apt/doc/apt-key.gpg
-  echo "deb [signed-by=$KEYRINGS_DIR/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | tee /etc/apt/sources.list.d/kubernetes.list
+  echo -e "\033[32mAdding Kubernetes community repository\033[0m"
+  curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.28/deb/Release.key | sudo gpg --dearmor -o $KEYRINGS_DIR/kubernetes-apt-keyring.gpg    
+  echo "deb [signed-by=$KEYRINGS_DIR/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.28/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 fi
 
 apt-get update -q
@@ -419,6 +419,26 @@ if [ $k8sVersion == "latest" ]; then
 else
   apt-get install -qqy kubelet=$k8sVersion kubeadm=$k8sVersion kubectl=$k8sVersion
 fi
+
+# Configuring Prerequisite https://v1-29.docs.kubernetes.io/docs/setup/production-environment/container-runtimes/
+
+echo -e "\033[32mConfiguring Prerequisites\033[0m"
+
+cat <<EOF | tee /etc/modules-load.d/k8s.conf
+overlay
+br_netfilter
+EOF
+
+modprobe overlay
+modprobe br_netfilter
+
+cat <<EOF | tee /etc/sysctl.d/k8s.conf
+net.bridge.bridge-nf-call-iptables  = 1
+net.bridge.bridge-nf-call-ip6tables = 1
+net.ipv4.ip_forward                 = 1
+EOF
+
+sysctl --system
 
 # Init Kubernetes https://kubernetes.io/docs/reference/setup-tools/kubeadm/kubeadm-init/
 

--- a/setup_worker_node.sh
+++ b/setup_worker_node.sh
@@ -247,9 +247,9 @@ fi
 # Add Kubernetes Respository
 
 if [ ! -f /etc/apt/sources.list.d/kubernetes.list ]; then
-  echo -e "\033[32mAdding Google Kubernetes repository\033[0m"
-  curl -fsSLo $KEYRINGS_DIR/kubernetes-archive-keyring.gpg https://dl.k8s.io/apt/doc/apt-key.gpg
-  echo "deb [signed-by=$KEYRINGS_DIR/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | tee /etc/apt/sources.list.d/kubernetes.list
+  echo -e "\033[32mAdding Kubernetes community repository\033[0m"
+  curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.28/deb/Release.key | sudo gpg --dearmor -o $KEYRINGS_DIR/kubernetes-apt-keyring.gpg    
+  echo "deb [signed-by=$KEYRINGS_DIR/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.28/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 fi
 
 apt-get update -q

--- a/setup_worker_node.sh
+++ b/setup_worker_node.sh
@@ -315,6 +315,26 @@ else
   apt-get install -qqy kubelet=$k8sVersion kubeadm=$k8sVersion kubectl=$k8sVersion
 fi
 
+# Configuring Prerequisite https://v1-29.docs.kubernetes.io/docs/setup/production-environment/container-runtimes/
+
+echo -e "\033[32mConfiguring Prerequisites\033[0m"
+
+cat <<EOF | tee /etc/modules-load.d/k8s.conf
+overlay
+br_netfilter
+EOF
+
+modprobe overlay
+modprobe br_netfilter
+
+cat <<EOF | tee /etc/sysctl.d/k8s.conf
+net.bridge.bridge-nf-call-iptables  = 1
+net.bridge.bridge-nf-call-ip6tables = 1
+net.ipv4.ip_forward                 = 1
+EOF
+
+sysctl --system
+
 # Join Cluster
 
 echo -e "\033[32mJoining Kubernetes Cluster\033[0m"


### PR DESCRIPTION
### 1.0.1
*March 23th 2025*

- Use community package repository (pkgs.k8s.io). (Google ones are dead)
- Use GitHub to determine latest version (required due to the above).
- Add validation for `--k8s-version` parameter.
- Reorder steps, placing prerequisite config between package install and `kubeadm [init|join]`. Also place splash and sudo checks at top of script.
- Add script version to banner.
- Change CIDR generator code so it doesn't break syntax highlighting.
- Added `--k8s-kubeadm-options` parameter.
- Added `set -euo pipefail` to terminate script on failure.
- Update documentation.
- Added 1 second sleep before `apt-get update` due to observed file locks / race conditions.
- Added changelog.md.

Tested with:

- Ubuntu Server 24.04
- Kubernetes Version 1.32.3
