### PR TITLE
Fix/k8s version

### DIFF
--- a/NodeParameters_Master.md
+++ b/NodeParameters_Master.md
@@ -15,7 +15,7 @@ Parameter values which are wrapped in quotes must include the quotes when applie
 |`--dns-servers`|The DNS servers to use.|`"8.8.8.8 4.4.4.4"`|`"192.168.0.2 192.168.0.3"`|No|
 |`--dns-search`|The local DNS search domains.|`"domain.local"`|`"example.com domain.internal"`|No|
 |`--k8s-cluster-name`|The name given to the cluster.|`kubernetes`|`cluster01`|No|
-|`--k8s-version`|The version of Kubernetes to install.|`latest`|`1.34.1`|No|
+|`--k8s-version`|The version of Kubernetes to install.|`latest`|`1.34` or `1.34.1`|No|
 |`--k8s-pod-network-cidr`|The CIDR for pod network.|`10.244.0.0/16`|`10.244.0.0/16`|No|
 |`--k8s-service-cidr`|The CIDR for services.|`10.96.0.0/12`|`10.96.0.0/12`|No|
 |`--k8s-load-balancer-ip-range`|The IP range or CIDR for Kubernetes load balancer.|-|`192.168.0.10-192.168.0.15`<br>or<br>`192.168.0.1/24`|Yes|
@@ -107,6 +107,7 @@ Example Usage - TCP/IP Setup:
 ```
 
 <br>
+
 Example Usage - Remote NFS Server:
 
 ```bash
@@ -118,6 +119,7 @@ Example Usage - Remote NFS Server:
 ```
 
 <br>
+
 Example Usage - Remote SMB Server:
 
 ```bash
@@ -132,6 +134,7 @@ Example Usage - Remote SMB Server:
 ```
 
 <br>
+
 Example Usage - No Storage (No CSI drivers or Storage Classes will be installed)
 
 ```bash
@@ -142,7 +145,8 @@ Example Usage - No Storage (No CSI drivers or Storage Classes will be installed)
 ```
 
 <br>
-Example Usage - Additional kubeadm init options
+
+Example Usage - Additional `kubeadm init` Options
 
 ```bash
 ./setup_master_node.sh \  
@@ -157,6 +161,27 @@ Example Usage - Additional kubeadm init options
 > Available options for `kubeadm init` [here](https://kubernetes.io/docs/reference/setup-tools/kubeadm/kubeadm-init/).
 
 <br>
+
+Example Usage - Kubeadm Config File
+
+```bash
+./setup_master_node.sh \    
+    --k8s-kubeadm-config /path/to/config.yaml \
+    --k8s-load-balancer-ip-range 192.168.0.1/24
+```
+> **NOTE:**<br>
+> The following parameters cannot be used when providing a kubeadm config file and should instead be set in the config file itself:
+> - `--k8s-cluster-name`
+> - `--k8s-version`
+> - `--k8s-pod-network-cidr`
+> - `--k8s-service-cidr`
+>
+> If the config file includes a `kubernetesVersion` field, the version will be extracted and used when installing the `kubeadm`, `kubelet` and `kubectl` packages.
+>
+> Note that using `--k8s-kubeadm-config` and `--k8s-kubeadm-options` used together may cause errors during initialization.
+
+<br>
+
 Example Usage - Kubernetes CNI
 
 ```bash
@@ -167,6 +192,7 @@ Example Usage - Kubernetes CNI
 > Currently the options are `flannel`, `cilium` or `none`. If you choose `none`, MetalLB will also be skipped, and your control-plane node will be in a `NotReady` state until you install your own CNI.
 
 <br>
+
 Example Usage - Flux CD
 
 _The below are examples of using Flux with a GitHub repository. Options are available for other Git providers. Please read the arguments above in conjunction with the official Flux documentation: https://fluxcd.io/flux/cmd/flux_bootstrap_git/_
@@ -204,6 +230,7 @@ This requires creating a PAT token at https://github.com/settings/personal-acces
 > You can override this behavior by passing the full directory with `--flux-git-path clusters/mycluster`.
 
 <br>
+
 Example Usage - All:
 
 ```bash

--- a/NodeParameters_Master.md
+++ b/NodeParameters_Master.md
@@ -15,7 +15,7 @@ Parameter values which are wrapped in quotes must include the quotes when applie
 |`--dns-servers`|The DNS servers to use.|`"8.8.8.8 4.4.4.4"`|`"192.168.0.2 192.168.0.3"`|No|
 |`--dns-search`|The local DNS search domains.|`"domain.local"`|`"example.com domain.internal"`|No|
 |`--k8s-cluster-name`|The name given to the cluster.|`kubernetes`|`cluster01`|No|
-|`--k8s-version`|The version of Kubernetes to install.|`latest`|`1.25.0-00`|No|
+|`--k8s-version`|The version of Kubernetes to install.|`latest`|`1.34.1`|No|
 |`--k8s-pod-network-cidr`|The CIDR for pod network.|`10.244.0.0/16`|`10.244.0.0/16`|No|
 |`--k8s-service-cidr`|The CIDR for services.|`10.96.0.0/12`|`10.96.0.0/12`|No|
 |`--k8s-load-balancer-ip-range`|The IP range or CIDR for Kubernetes load balancer.|-|`192.168.0.10-192.168.0.15`<br>or<br>`192.168.0.1/24`|Yes|

--- a/NodeParameters_Worker.md
+++ b/NodeParameters_Worker.md
@@ -17,7 +17,7 @@ Parameters that have default values but are marked as required can still be ommi
 |`--default-gateway`|The default gateway to use.|-|`192.168.0.1`|When `--configure-tcpip` is `true`|
 |`--dns-servers`|The DNS servers to use.|`"8.8.8.8 4.4.4.4"`|`"192.168.0.2 192.168.0.3"`|No|
 |`--dns-search`|The local DNS search domains.|`"domain.local"`|`"example.com domain.internal"`|No|
-|`--k8s-version`|The version of Kubernetes to install.|`latest`|`1.25.0-00`|No|
+|`--k8s-version`|The version of Kubernetes to install.|`latest`|`1.34` or `1.34.1`|No|
 |`--k8s-master-ip`|The IP address of the control-plane node.|-|`192.168.0.10`|Yes|
 |`--k8s-master-port`|The Kubernetes API server port on the control-plane node.|`6443`|`6443`|Yes|
 |`--k8s-kubeadm-options`|Additional options to pass into the `kubeadm join` command.|-|`"--ignore-preflight-errors=all"`|No|
@@ -33,6 +33,7 @@ The `--token` and `--discovery-token-ca-cert-hash` parameters should be exactly 
 ## Parameter Examples
 
 <br>
+
 Example Usage - Minimum Required:
 
 ```bash
@@ -43,6 +44,7 @@ Example Usage - Minimum Required:
 ```
 
 <br>
+
 Example Usage - Additional kubeadm join options
 
 ```bash
@@ -52,6 +54,7 @@ Example Usage - Additional kubeadm join options
 > Available options for `kubeadm join` [here](https://kubernetes.io/docs/reference/setup-tools/kubeadm/kubeadm-join/). <br> **Do not** include `--token` or `--discovery-token-ca-cert-hash` as these are already set in the script.
 
 <br>
+
 Example Usage - All:
 
 ```bash

--- a/changelog.md
+++ b/changelog.md
@@ -1,9 +1,11 @@
 
-### 1.6.0
-*September 16th 2025*
+### 1.6.1
+*September 17th 2025*
 
-- Fix k8s version parameter to allow build version (1.23.45)
-- Only grab latest version from GitHub when `$k8sVersion` is `latest`
+- Fix kubernetes version parameter to allow and use patch version (1.23.45)
+- Extract kubernetes version from kubeadm config file if provided.
+- Only grab latest version from GitHub when `$k8sVersion` is `latest`.
+- Packages kubeadm, kubelet and kubectl now marked `hold`. 
 
 ---
 ### 1.6.0

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,12 @@
 
 ### 1.6.0
+*September 16th 2025*
+
+- Fix k8s version parameter to allow build version (1.23.45)
+- Only grab latest version from GitHub when `$k8sVersion` is `latest`
+
+---
+### 1.6.0
 *September 14th 2025*
 
 - Add support for Flux CD !

--- a/setup_master_node.sh
+++ b/setup_master_node.sh
@@ -767,7 +767,7 @@ fi
 # Init Kubernetes https://kubernetes.io/docs/reference/setup-tools/kubeadm/kubeadm-init/
 
 if [[ -z "$k8sKubeadmConfig" && "$k8sClusterName" == "kubernetes" ]]; then  
-  export KUBEADM_ARGS="--apiserver-advertise-address=$ipAddress --pod-network-cidr=$k8sPodNetworkCIDR --service-cidr=$k8sServiceCIDR  --kubernetes-version=$KUBEADM_VERSION"
+  export KUBEADM_ARGS="--apiserver-advertise-address=$ipAddress --pod-network-cidr=$k8sPodNetworkCIDR --service-cidr=$k8sServiceCIDR --kubernetes-version=$KUBEADM_VERSION"
 else 
   if [[ -z "$k8sKubeadmConfig" ]]; then
     export k8sKubeadmConfig="/tmp/kubeadm-config.yaml"

--- a/setup_master_node.sh
+++ b/setup_master_node.sh
@@ -6,7 +6,7 @@ echo -e '\e[35m     / \  _   _| |_ ___ \e[36m| | _( _ ) ___  \e[0m'
 echo -e '\e[35m    / ▲ \| | | | __/   \\\e[36m| |/ /   \/ __| \e[0m'
 echo -e '\e[35m   / ___ \ |_| | ||  ●  \e[36m|   <  ♥  \__ \ \e[0m'
 echo -e '\e[35m  /_/   \_\__,_|\__\___/\e[36m|_|\_\___/|___/ \e[0m'
-echo -e '\e[35m                Version:\e[36m 1.6.0\e[0m\n'
+echo -e '\e[35m                Version:\e[36m 1.6.1\e[0m\n'
 echo -e '\e[35m  Kubernetes Installation Script:\e[36m Control-Plane Edition\e[0m\n'
 
 # Check sudo & keep sudo running
@@ -262,7 +262,7 @@ if [[ "$configureTCPIPSetting" == true ]]; then
   done
 fi
 
-if [[ ! $k8sVersion =~ ^(latest)$|^[0-9]{1,2}\.[0-9]{1,2}$ ]]; then
+if [[ ! $k8sVersion =~ ^(latest)$|^[0-9]{1,2}(\.[0-9]{1,2}){1,2}$ ]]; then
     echo -e "\e[31mError:\e[0m \e[35m--k8s-version\e[0m value \e[35m$k8sVersion\e[0m is not in the correct format."
     PARAM_CHECK_PASS=false
 fi
@@ -626,10 +626,8 @@ echo -e "\033[32mInstalling Kubernetes\033[0m"
 
 # Discover latest kubernetes version
 
-export K8S_LATEST_VERSION=$(curl -s https://api.github.com/repos/kubernetes/kubernetes/releases/latest | grep tag_name | cut -d '"' -f4 | sed 's/^v//')
-
 if [ $k8sVersion == "latest" ]; then
-  k8sVersion=$K8S_LATEST_VERSION
+  k8sVersion=$(curl -s https://api.github.com/repos/kubernetes/kubernetes/releases/latest | grep tag_name | cut -d '"' -f4 | sed 's/^v//')
   echo "Detected latest Kubernetes version: $k8sVersion"
 fi
 

--- a/setup_master_node.sh
+++ b/setup_master_node.sh
@@ -61,7 +61,7 @@ export k8sKubeadmConfig=""                                  # Path to kubeadm co
 # Kubernetes Storage Classes
 # ------------------------------
 # If the 'nfsInstallServer' or 'smbInstallServer' values are set to 'false' but the 'nfsServer' or 'smbServer' values are set to anything 
-# other than this machines hostname, the CSI driver(s) will be installed and storage class(es) created and configured for the specifed server(s).
+# other than this machines hostname, the CSI driver(s) will be installed and storage class(es) created and configured for the specified server(s).
 #
 # WARNING: Using the master node as a storage server is not standard practice nor recommended. This option exists so that those who are new to k8s
 # can quickly and easily try out Kubernetes features and applications that rely on persistent storage. Do not do this in a production environment.
@@ -657,10 +657,10 @@ echo "Using APT repo: $K8S_REPO_VERSION"
 
 if [ -n "$K8S_PATCH" ]; then  
   VER_REGEX="^${K8S_MAJ}\\\\.${K8S_MIN}\\\\.${K8S_PATCH}-"
-  KUBEADM_VERSION_FLAG="v${K8S_MAJ}.${K8S_MIN}.${K8S_PATCH}"
+  KUBEADM_VERSION="v${K8S_MAJ}.${K8S_MIN}.${K8S_PATCH}"
 else  
   VER_REGEX="^${K8S_MAJ}\\\\.${K8S_MIN}\\\\.[0-9]+-"  
-  KUBEADM_VERSION_FLAG=""
+  KUBEADM_VERSION=""
 fi
 
 # Add Kubernetes Respository
@@ -690,11 +690,11 @@ if [ -z "$kubeadm_ver" ] || [ -z "$kubelet_ver" ] || [ -z "$kubectl_ver" ]; then
   exit 1
 fi
 
-if [ -z "$KUBEADM_VERSION_FLAG" ]; then  
-  KUBEADM_VERSION_FLAG="v$(echo "$kubeadm_ver" | cut -d- -f1)"
+if [ -z "$KUBEADM_VERSION" ]; then  
+  KUBEADM_VERSION="v$(echo "$kubeadm_ver" | cut -d- -f1)"
 fi
 
-echo "Using kubeadm version: $KUBEADM_VERSION_FLAG"
+echo "Using kubeadm version: $KUBEADM_VERSION"
 
 apt-get install -qqy $APT_LOCK kubeadm="$kubeadm_ver" kubelet="$kubelet_ver" kubectl="$kubectl_ver"
 
@@ -743,7 +743,7 @@ fi
 # Init Kubernetes https://kubernetes.io/docs/reference/setup-tools/kubeadm/kubeadm-init/
 
 if [[ -z "$k8sKubeadmConfig" && "$k8sClusterName" == "kubernetes" ]]; then  
-  export KUBEADM_ARGS="--apiserver-advertise-address=$ipAddress --pod-network-cidr=$k8sPodNetworkCIDR --service-cidr=$k8sServiceCIDR"
+  export KUBEADM_ARGS="--apiserver-advertise-address=$ipAddress --pod-network-cidr=$k8sPodNetworkCIDR --service-cidr=$k8sServiceCIDR  --kubernetes-version=$KUBEADM_VERSION"
 else 
   if [[ -z "$k8sKubeadmConfig" ]]; then
     export k8sKubeadmConfig="/tmp/kubeadm-config.yaml"
@@ -757,6 +757,7 @@ localAPIEndpoint:
 apiVersion: kubeadm.k8s.io/v1beta4
 kind: ClusterConfiguration
 clusterName: "$k8sClusterName"
+kubernetesVersion: "$KUBEADM_VERSION"
 networking:
   podSubnet: "$k8sPodNetworkCIDR"
   serviceSubnet: "$k8sServiceCIDR"
@@ -770,7 +771,7 @@ fi
 
 echo -e "\033[32mInitilizing Kubernetes\033[0m"
 
-kubeadm init $KUBEADM_ARGS $k8sKubeadmOptions --kubernetes-version "$KUBEADM_VERSION_FLAG"
+kubeadm init $KUBEADM_ARGS $k8sKubeadmOptions
 
 # Setup kube config files.
 

--- a/setup_master_node.sh
+++ b/setup_master_node.sh
@@ -215,7 +215,7 @@ if [[ ! "$k8sAllowMasterNodeSchedule" =~ ^(true|false)$ ]]; then
 elif [[ "$k8sAllowMasterNodeSchedule" == false ]]; then
   cnischedulewarn=""
   if [ $k8sCNI == "cilium" ]; then cnischedulewarn=" and some Cilium pods"; fi
-  echo -e "\e[33mWarning:\e[0m Master (control-plane) node scheduling will not be enabled. This means that non-core pods will not be scheduled until a worker node is added to the cluster. This includes Metal LB$cnischedulewarn which will result in networking issues."
+  echo -e "\e[33mWarning:\e[0m Master (control-plane) node scheduling will not be enabled. This means that non-core pods will not be scheduled until a worker node is added to the cluster."
   PARAM_CHECK_WARN=true
 fi
 
@@ -262,7 +262,7 @@ if [[ "$configureTCPIPSetting" == true ]]; then
   done
 fi
 
-if [[ ! $k8sVersion =~ ^(latest)$|^[0-9]{1,2}(\.[0-9]{1,2}){1,2}$ ]]; then
+if [[ ! $k8sVersion =~ ^(latest|[0-9]{1,2}(\.[0-9]{1,2}){1,2})$ ]]; then
     echo -e "\e[31mError:\e[0m \e[35m--k8s-version\e[0m value \e[35m$k8sVersion\e[0m is not in the correct format."
     PARAM_CHECK_PASS=false
 fi

--- a/setup_master_node.sh
+++ b/setup_master_node.sh
@@ -339,8 +339,8 @@ if [[ ! -z "$k8sKubeadmConfig" && "$k8sClusterName" != "kubernetes" ]]; then
 fi
 
 if [[ ! -z "$k8sKubeadmConfig" && "$k8sVersion" != "latest" ]]; then
-    echo -e "\e[31mError:\e[0m \e[35m--k8s-kubeadm-config\e[0m and \e[35m--k8s-version\e[0m cannot be used at the same time. (Define this in your config file instead).\e[0m"
-    PARAM_CHECK_PASS=false
+  echo -e "\e[31mError:\e[0m \e[35m--k8s-kubeadm-config\e[0m and \e[35m--k8s-version\e[0m cannot be used at the same time. (Define this in your config file instead).\e[0m"
+  PARAM_CHECK_PASS=false
 fi
 
 if [[ ! -z "$k8sKubeadmConfig" && ! -z "$k8sKubeadmOptions" ]]; then
@@ -356,9 +356,9 @@ elif [[ ! -z "$k8sKubeadmConfig" ]]; then
   CONFIG_K8S_VERSION=$(echo "$CONFIG_FILE_CONTENT" | grep "kubernetesVersion:" || true)
   if [[ "$CONFIG_K8S_VERSION" =~ ^kubernetesVersion ]]; then
     k8sVersion=$(echo "$CONFIG_K8S_VERSION" | grep "kubernetesVersion:" | awk '{print $2}' | sed 's/\"//g' | sed "s/'//g")
-    if [[ ! $k8sVersion =~ ^[0-9]{1,2}(\.[0-9]{1,2}){2}$ ]]; then
-        echo -e "\e[31mError:\e[0m The Kubernetes version \e[35m$k8sVersion\e[0m specified in your kubeadm config file is not in the correct format."
-        PARAM_CHECK_PASS=false
+    if [[ ! $k8sVersion =~ ^v[0-9]{1,2}(\.[0-9]{1,2}){2}$ ]]; then
+      echo -e "\e[31mError:\e[0m The Kubernetes version \e[35m$k8sVersion\e[0m specified in your kubeadm config file is not in the correct format. Should be vX.Y.Z e.g. v1.34.0"
+      PARAM_CHECK_PASS=false
     fi
   fi
 fi
@@ -542,7 +542,7 @@ echo -e "\e[32mInfo:\e[0m The service network will be \e[35m$k8sServiceCIDR\e[0m
 if [[ "$k8sVersion" == "latest" ]]; then
   echo -e "\e[32mInfo:\e[0m The latest stable Kubernetes version will be installed."
 else
-  echo -e "\e[32mInfo:\e[0m Kubernetes version \e[35m$k8sVersion\e[0m will be installed."
+  echo -e "\e[32mInfo:\e[0m Kubernetes version \e[35m$(echo $k8sVersion | sed 's/^v//')\e[0m will be installed."
 fi
 
 # Install Kubernetes

--- a/setup_worker_node.sh
+++ b/setup_worker_node.sh
@@ -418,7 +418,7 @@ fi
 
 echo -e "\033[32mJoining Kubernetes Cluster\033[0m"
 
-kubeadm join $k8sMasterIP:$k8sMasterPort --token $k8sToken --discovery-token-ca-cert-hash $k8sTokenDiscoveryCaCertHash --kubernetes-version=$KUBEADM_VERSION $k8sKubeadmOptions
+kubeadm join $k8sMasterIP:$k8sMasterPort --token $k8sToken --discovery-token-ca-cert-hash $k8sTokenDiscoveryCaCertHash $k8sKubeadmOptions
 
 # Print success message
 

--- a/setup_worker_node.sh
+++ b/setup_worker_node.sh
@@ -337,7 +337,7 @@ else
   KUBEADM_VERSION=""
 fi
 
-# Add Kubernetes Respository
+# Add Kubernetes Repository
 
 if [ -f /etc/apt/sources.list.d/kubernetes.list ]; then
   rm $KEYRINGS_DIR/kubernetes-apt-keyring.gpg
@@ -374,7 +374,7 @@ apt-get install -qqy $APT_LOCK kubeadm="$kubeadm_ver" kubelet="$kubelet_ver" kub
 
 apt-mark hold kubeadm kubelet kubectl
 
-# Configuring Prerequisite
+# Configuring Prerequisites
 
 echo -e "\033[32mEnable IPv4 packet forwarding\033[0m"
 

--- a/setup_worker_node.sh
+++ b/setup_worker_node.sh
@@ -6,14 +6,13 @@ echo -e '\e[35m     / \  _   _| |_ ___ \e[36m| | _( _ ) ___  \e[0m'
 echo -e '\e[35m    / ▲ \| | | | __/   \\\e[36m| |/ /   \/ __| \e[0m'
 echo -e '\e[35m   / ___ \ |_| | ||  ●  \e[36m|   <  ♥  \__ \ \e[0m'
 echo -e '\e[35m  /_/   \_\__,_|\__\___/\e[36m|_|\_\___/|___/ \e[0m'
-echo -e '\e[35m                Version:\e[36m 1.6.0\e[0m\n'
+echo -e '\e[35m                Version:\e[36m 1.6.1\e[0m\n'
 echo -e '\e[35m  Kubernetes Installation Script:\e[36m Worker Node Edition\e[0m\n'
 
 # Check sudo & keep sudo running
 # --------------------------------------------------------------------------------------------------------------------------------------------------------
 
-if [ "$(id -u)" -ne 0 ]
-then
+if [ "$(id -u)" -ne 0 ]; then
   echo -e "\033[31mYou must run this script as root\033[0m"
   exit
 fi

--- a/setup_worker_node.sh
+++ b/setup_worker_node.sh
@@ -152,7 +152,7 @@ if [[ "$configureTCPIPSetting" == true ]]; then
   done
 fi
 
-if [[ ! $k8sVersion =~ ^(latest)$|^[0-9]{1,2}\.[0-9]{1,2}$ ]]; then
+if [[ ! $k8sVersion =~ ^(latest|[0-9]{1,2}(\.[0-9]{1,2}){1,2})$ ]]; then
     echo -e "\e[31mError:\e[0m \e[35m--k8s-version\e[0m value \e[35m$k8sVersion\e[0m is not in the correct format."
     PARAM_CHECK_PASS=false
 fi


### PR DESCRIPTION
- Fix kubernetes version parameter to allow and use patch version (1.23.45)
- Extract kubernetes version from kubeadm config file if provided.
- Only grab latest version from GitHub when `$k8sVersion` is `latest`.
- Packages kubeadm, kubelet and kubectl now marked `hold`. 
- Update docs