### PR TITLE
Fix/metallb race condition

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 *July 7th 2026*
 
 - Fix MetalLB Speaker and FFR tolerations not being applied.
+- Fix race condition with MetalLB IPAddressPool resource creation and validating webhook
 
 ## 1.7.0
 *October 17th 2025*

--- a/setup_master_node.sh
+++ b/setup_master_node.sh
@@ -1182,7 +1182,13 @@ metadata:
   namespace: metallb-system
 EOF
 
-  kubectl apply -f $METALLB_IPPOOL_L2AD -n metallb-system
+  for i in $(seq 1 30); do
+    if kubectl apply -f $METALLB_IPPOOL_L2AD -n metallb-system; then
+      break
+    fi
+    echo "MetalLB webhook not ready yet, retrying ($i/30)..."
+    sleep 5
+  done
   rm $METALLB_IPPOOL_L2AD
 else
   echo -e "\033[33mSkipping Metal LB step. You will need to run this manually once you've installed a CNI in order to access your pods from your local network.\033[0m"


### PR DESCRIPTION
Fixes race condition in which we attempt to apply the `IPAddressPool` resource before the validation webook is ready. 